### PR TITLE
Fixed activeAdBreak / activeAd being nil

### DIFF
--- a/BitmovinYoSpaceModule/Classes/BitmovinYospacePlayer.swift
+++ b/BitmovinYoSpaceModule/Classes/BitmovinYospacePlayer.swift
@@ -266,11 +266,11 @@ open class BitmovinYospacePlayer: BitmovinPlayer {
     }
 
     public func getActiveAdBreak() -> AdBreak? {
-        return self.timeline?.currentAdBreak(time: self.currentTime)
+        return self.timeline?.currentAdBreak(time: self.currentTimeWithAds())
     }
 
     public func getActiveAd() -> Ad? {
-        return self.timeline?.currentAd(time: self.currentTime)
+        return self.timeline?.currentAd(time: self.currentTimeWithAds())
     }
 }
 


### PR DESCRIPTION
 - When calculating the activeAdBreak and activeAd we need to use the `currentTimeWithAds()` method. If we do not, we get a `currentTime` related to the ad playback and `getActiveAdBreak()` and `getActiveAd()` are `nil`