### PR TITLE
Fix no ABS event fired

### DIFF
--- a/BitmovinYoSpaceModule/Classes/BitmovinYospacePlayer.swift
+++ b/BitmovinYoSpaceModule/Classes/BitmovinYospacePlayer.swift
@@ -337,16 +337,15 @@ extension BitmovinYospacePlayer: YSAnalyticObserver {
     public func advertBreakDidStart(_ adBreak: YSAdBreak) {
         var adBreakStartEvent: AdBreakStartedEvent = AdBreakStartedEvent()
         #if os(iOS)
-        guard let truexAdRenderer = truexAdRenderer else {
-            return
-        }
-        if truexAdRenderer.adFree {
-            BitLog.d("Skipping Ad Break due to TrueX ad free experience")
-            super.seek(time: adBreak.adBreakEnd())
-        } else {
-            BitLog.d("Rendering TrueX Ad")
-            trueXRendering = truexAdRenderer.renderTruex(adverts: adBreak.adverts())
-            BitLog.d("TrueX Ad Rendered - \(trueXRendering)")
+        if truexAdRenderer != nil {
+            if truexAdRenderer!.adFree {
+                BitLog.d("Skipping Ad Break due to TrueX ad free experience")
+                super.seek(time: adBreak.adBreakEnd())
+            } else {
+                BitLog.d("Rendering TrueX Ad")
+                trueXRendering = truexAdRenderer!.renderTruex(adverts: adBreak.adverts())
+                BitLog.d("TrueX Ad Rendered - \(trueXRendering)")
+            }
         }
         #endif
 


### PR DESCRIPTION
`AdBreakStarted` event was consumed when `truexAdRenderer` was nil. This would happen if no `TruexConfiguration` was passed to the `load` call.

Fixes issue [tub-lib#370](https://github.com/TurnerOpenPlatform/tub-lib/issues/370)