### PR TITLE
OnAdFree seek to the end of the ad break 

### DIFF
--- a/BitmovinYoSpaceModule/Classes/BitmovinTruexAdRenderer.swift
+++ b/BitmovinYoSpaceModule/Classes/BitmovinTruexAdRenderer.swift
@@ -102,6 +102,7 @@ class BitmovinTruexAdRenderer: NSObject, TruexAdRendererDelegate {
             return
         }
         self.bitmovinPlayer?.forceSeek(time: adBreak.absoluteEnd+1)
+        self.bitmovinPlayer?.handleTrueXAdFree()
     }
 
     public func onPopupWebsite(_ url: String!) {

--- a/BitmovinYoSpaceModule/Classes/BitmovinYospacePlayer.swift
+++ b/BitmovinYoSpaceModule/Classes/BitmovinYospacePlayer.swift
@@ -212,6 +212,12 @@ open class BitmovinYospacePlayer: BitmovinPlayer {
         super.seek(time: time)
     }
 
+    func handleTrueXAdFree() {
+        for listener: YospaceListener in yospaceListeners {
+            listener.onTrueXAdFree()
+        }
+    }
+
     // MARK: - event handling
     open override func add(listener: PlayerListener) {
         listeners.append(listener)

--- a/BitmovinYoSpaceModule/Classes/YospaceListener.swift
+++ b/BitmovinYoSpaceModule/Classes/YospaceListener.swift
@@ -11,4 +11,5 @@ import BitmovinPlayer
 public protocol YospaceListener: class {
     func onYospaceError(event: ErrorEvent)
     func onTimelineChanged(event: AdTimelineChangedEvent)
+    func onTrueXAdFree()
 }

--- a/Example/BitmovinYospaceModule_Example_tvOS/ViewController.swift
+++ b/Example/BitmovinYospaceModule_Example_tvOS/ViewController.swift
@@ -173,4 +173,8 @@ extension ViewController: YospaceListener {
     public func onTimelineChanged(event: AdTimelineChangedEvent) {
 
     }
+    
+    public func onTrueXAdFree() {
+        
+    }
 }


### PR DESCRIPTION
**Issue**
When seeking out of a TrueX ad that had been watched, the TrueXRender was seeking to the end of the current ad, not the current ad break. This caused the user to still have to watch one preroll ad when the preroll adBreak had more than one ad in it. 

**Fix**
Seek to the end of the `adBreak` instead of the end of the `ad`