### PR TITLE
Minor event delegating fixes

### DIFF
--- a/BitmovinYoSpaceModule/Classes/BitmovinYospacePlayer.swift
+++ b/BitmovinYoSpaceModule/Classes/BitmovinYospacePlayer.swift
@@ -857,7 +857,7 @@ public extension BitmovinYospacePlayer {
 // MARK: - PlayerListener
 
 extension BitmovinYospacePlayer: PlayerListener {
-    public func onPlay(_ event: PlayerEvent, player: Player) {
+    public func onPlay(_ event: PlayEvent, player: Player) {
         BitLog.d("onPlayer: \(event)")
 
         for listener: PlayerListener in listeners {
@@ -1068,7 +1068,7 @@ extension BitmovinYospacePlayer: PlayerListener {
         }
     }
 
-    public func onEvent(_ event: PlayerEvent, player: Player) {
+    public func onEvent(_ event: Event, player: Player) {
         for listener: PlayerListener in listeners {
             listener.onEvent?(event, player: player)
         }

--- a/BitmovinYoSpaceModule/Classes/BitmovinYospacePlayer.swift
+++ b/BitmovinYoSpaceModule/Classes/BitmovinYospacePlayer.swift
@@ -356,7 +356,7 @@ public class BitmovinYospacePlayer: NSObject, Player {
         }
 
         if self.sourceConfig?.type != .hls {
-            onError(YospaceErrorEvent(errorCode: .invalidSource, message: "Invalid source provided. Yospace URL must be HLS"), player: self)
+            emitYoSpaceError(YospaceErrorEvent(errorCode: .invalidSource, message: "Invalid source provided. Yospace URL must be HLS"), player: self)
             return
         }
 
@@ -781,6 +781,14 @@ public extension BitmovinYospacePlayer {
             listener.onAdBreakStarted?(adBreakStartEvent, player: self)
         }
     }
+
+    private func emitYoSpaceError(_ event: YospaceErrorEvent, player: Player) {
+        listeners.forEach { $0.onEvent?(event, player: player) }
+    }
+
+    private func emitYoSpaceWarning(_ event: YospaceWarningEvent, player: Player) {
+        listeners.forEach { $0.onEvent?(event, player: player) }
+    }
 }
 
 // MARK: - YSAnalyticsObserver
@@ -803,10 +811,10 @@ public extension BitmovinYospacePlayer {
             BitLog.e("Not initialized url:\(stream.playbackUrl ?? "none") itemId:\(stream.identifier ?? "none")")
             if let sourceConfiguration = sourceConfig, yospaceSourceConfig?.retryExcludingYospace == true {
                 BitLog.w("Attempting to playback the stream url without Yospace")
-                onWarning(YospaceWarningEvent(errorCode: .notIntialised, message: "Yospace not initialized"), player: self)
+                emitYoSpaceWarning(YospaceWarningEvent(errorCode: .notIntialised, message: "Yospace not initialized"), player: self)
                 load(sourceConfig: sourceConfiguration)
             } else {
-                onError(YospaceErrorEvent(errorCode: .notIntialised, message: "Yospace not initialized"), player: self)
+                emitYoSpaceError(YospaceErrorEvent(errorCode: .notIntialised, message: "Yospace not initialized"), player: self)
             }
         case .noAnalytics:
             // store the session
@@ -815,10 +823,10 @@ public extension BitmovinYospacePlayer {
             BitLog.d("No Analytics url:\(stream.playbackUrl ?? "none") itemId:\(stream.identifier ?? "none")")
             if let sourceConfiguration = sourceConfig, yospaceSourceConfig?.retryExcludingYospace == true {
                 BitLog.w("Attempting to playback the stream url without Yospace")
-                onWarning(YospaceWarningEvent(errorCode: .noAnalytics, message: "No analytics"), player: self)
+                emitYoSpaceWarning(YospaceWarningEvent(errorCode: .noAnalytics, message: "No analytics"), player: self)
                 load(sourceConfig: sourceConfiguration)
             } else {
-                onError(YospaceErrorEvent(errorCode: .noAnalytics, message: "No analytics"), player: self)
+                emitYoSpaceError(YospaceErrorEvent(errorCode: .noAnalytics, message: "No analytics"), player: self)
             }
         case .initialised:
             // store the session
@@ -840,13 +848,13 @@ public extension BitmovinYospacePlayer {
     func operationDidFailWithError(_ error: Error) {
         if let sourceConfig = sourceConfig, yospaceSourceConfig?.retryExcludingYospace == true {
             BitLog.w("Attempting to playback the stream url without Yospace")
-            onWarning(
+            emitYoSpaceWarning(
                 YospaceWarningEvent(errorCode: .unknownError, message: "Unknown Error. Initialize failed with Error:" + error.localizedDescription),
                 player: self
             )
             load(sourceConfig: sourceConfig)
         } else {
-            onError(
+            emitYoSpaceError(
                 YospaceErrorEvent(errorCode: .unknownError, message: "Unknown Error. Initialize failed with Error:" + error.localizedDescription),
                 player: self
             )
@@ -916,16 +924,12 @@ extension BitmovinYospacePlayer: PlayerListener {
         }
     }
 
-    public func onWarning(_ event: YospaceWarningEvent, player: Player) {
-        for listener: PlayerListener in listeners {
-            listener.onEvent?(event, player: player)
-        }
+    public func onPlayerError(_ event: PlayerErrorEvent, player: Player) {
+        listeners.forEach { $0.onPlayerError?(event, player: player) }
     }
 
-    public func onError(_ event: YospaceErrorEvent, player: Player) {
-        for listener: PlayerListener in listeners {
-            listener.onEvent?(event, player: player)
-        }
+    public func onSourceError(_ event: SourceErrorEvent, player: Player) {
+        listeners.forEach { $0.onSourceError?(event, player: player) }
     }
 
     public func onReady(_ event: ReadyEvent, player: Player) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Missing `PlayEvent`, `PlayerErrorEvent` and `PlayerSourceEvent`` from `BitmovinYospacePlayer`
+- `PlayerListener.onEvent` not receiving events through `BitmovinYospacePlayer`
+
 ## 2.0.0 - 2023-07-04
 
 ### Changed
@@ -34,7 +38,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## 1.22.0
 
 ### Changed
-- Bitmovin player to `2.60.0` 
+- Bitmovin player to `2.60.0`
 
 ## 1.21.0
 
@@ -52,7 +56,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `creativeId`, `sequence`, `title`, `avertiser`, `system`, `lineage` and `isFiller` properties to `YospaceAd`
 
 ### Changed
-- Bitmovin player to `2.59.0` 
+- Bitmovin player to `2.59.0`
 - `id` property from `YospaceAd` now returns shortened identifier
 - `mediaFileUrl` property from `YospaceAd` now returns the interactive unit source
 - `AdBreakPosition` to `YospaceAdBreakPosition`
@@ -60,7 +64,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## 1.19.0
 
 ### Changed
-- Bitmovin player to `2.57.1` 
+- Bitmovin player to `2.57.1`
 
 ## 1.18.0
 
@@ -88,7 +92,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## 1.16.0
 
 ### Changed
-- Bitmovin player to `2.55.0` 
+- Bitmovin player to `2.55.0`
 
 ## 1.15.0
 
@@ -98,7 +102,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## 1.14.0
 
 ### Added
-- `suppressAnalytics()` to `BitmovinYospacePlayer`, which suppresses creative tracking beacons 
+- `suppressAnalytics()` to `BitmovinYospacePlayer`, which suppresses creative tracking beacons
 
 ### Changed
 - Yospace SDK to `1.12.0`
@@ -111,7 +115,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## 1.13.0
 
 ### Changed
-- Bitmovin Player to `2.53.0` 
+- Bitmovin Player to `2.53.0`
 
 ## 1.12.0
 
@@ -122,7 +126,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## 1.11.0
 
 ### Changed
-- Bitmovin player to `2.51.0` 
+- Bitmovin player to `2.51.0`
 
 ## 1.10.1
 
@@ -132,12 +136,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## 1.10.0
 
 ### Changed
-- Bitmovin player to `2.50.0` 
+- Bitmovin player to `2.50.0`
 
 ## 1.9.0
 
 ### Changed
-- Bitmovin player to `2.49.0` 
+- Bitmovin player to `2.49.0`
 
 ## 1.8.0
 
@@ -150,7 +154,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## 1.7.0
 
 ### Changed
-- Bitmovin player to `2.48.0` 
+- Bitmovin player to `2.48.0`
 
 ## 1.6.1
 
@@ -173,7 +177,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `position` (pre/mid/post roll or unknown) to `AdBreak`
 
 ### Changed
-- Bitmovin player to `2.45.0` 
+- Bitmovin player to `2.45.0`
 - Yospace errors to be emitted in the `PlayerListener`
 
 ### Removed
@@ -193,7 +197,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## 1.2.11
 
 ### Fixed
-- tvOS TruexRenderer build issues 
+- tvOS TruexRenderer build issues
 - `truexAd` in `YospaceAdStartedEvent` not being respected
 
 ## 1.2.10
@@ -216,7 +220,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## 1.2.8
 
 ### Changed
-- Bitmovin player to `2.41.0` 
+- Bitmovin player to `2.41.0`
 - Yospace SDK to `1.10.0`
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Fixed
-- Missing `PlayEvent`, `PlayerErrorEvent` and `PlayerSourceEvent`` from `BitmovinYospacePlayer`
+- Missing `PlayEvent`, `PlayerErrorEvent` and `PlayerSourceEvent` from `BitmovinYospacePlayer`
 - `PlayerListener.onEvent` not receiving events through `BitmovinYospacePlayer`
 
 ## 2.0.0 - 2023-07-04

--- a/Example/BitmovinYoSpaceModule/ViewController.swift
+++ b/Example/BitmovinYoSpaceModule/ViewController.swift
@@ -233,7 +233,15 @@ extension ViewController: PlayerListener {
         loadUnloadButton.setTitle("Load", for: .normal)
     }
 
-    func onError(_ event: Event, player _: Player) {
-        print("[onError] \(event.description)")
+    func onPlayerError(_ event: PlayerErrorEvent, player: Player) {
+        print("[PlayerError] \(event.message)")
+    }
+
+    func onSourceError(_ event: SourceErrorEvent, player: Player) {
+        print("[SourceError] \(event.message)")
+    }
+
+    func onEvent(_ event: Event, player: Player) {
+        print("[Event]: \(event.name)")
     }
 }

--- a/Example/BitmovinYoSpaceModule/ViewController.swift
+++ b/Example/BitmovinYoSpaceModule/ViewController.swift
@@ -242,6 +242,6 @@ extension ViewController: PlayerListener {
     }
 
     func onEvent(_ event: Event, player: Player) {
-        print("[Event]: \(event.name)")
+        print("[Event] \(event.name)")
     }
 }


### PR DESCRIPTION
## Description
### Problem
There were a couple of warnings regarding methods which almost match the method signatures of the `PlayerListener`. Due to them not match, those events were not delegated through the `BitmovinYospacePlayer` and were missing.

![Screenshot 2024-05-06 at 13 15 39](https://github.com/bitmovin/bitmovin-player-ios-integrations-yospace/assets/6216959/7424d5b0-534b-4a23-aeff-bd9303cf9aae)

### Changes
- Fixing all of those wrong listener function
- Streamlined the error/warning emitting for custom `YospaceErrorEvents`
