### PR TITLE
Change dependency to `BitmovinPlayerCore`

### DIFF
--- a/BitmovinYoSpaceModule/Classes/AdTimeline.swift
+++ b/BitmovinYoSpaceModule/Classes/AdTimeline.swift
@@ -1,4 +1,4 @@
-import BitmovinPlayer
+import BitmovinPlayerCore
 import Foundation
 import YOAdManagement
 

--- a/BitmovinYoSpaceModule/Classes/BitmovinTruexRenderer.swift
+++ b/BitmovinYoSpaceModule/Classes/BitmovinTruexRenderer.swift
@@ -1,4 +1,4 @@
-import BitmovinPlayer
+import BitmovinPlayerCore
 import Foundation
 import TruexAdRenderer
 import YOAdManagement

--- a/BitmovinYoSpaceModule/Classes/BitmovinYospacePlayer.swift
+++ b/BitmovinYoSpaceModule/Classes/BitmovinYospacePlayer.swift
@@ -1,4 +1,4 @@
-import BitmovinPlayer
+import BitmovinPlayerCore
 import UIKit
 import YOAdManagement
 
@@ -43,7 +43,7 @@ public class BitmovinYospacePlayer: NSObject, Player {
 
     public var config: PlayerConfig { return player.config }
 
-    public var source: BitmovinPlayer.Source? { return player.source }
+    public var source: Source? { return player.source }
 
     public var maxTimeShift: TimeInterval { return player.maxTimeShift }
 
@@ -52,13 +52,13 @@ public class BitmovinYospacePlayer: NSObject, Player {
         set { player.timeShift = newValue }
     }
 
-    public var availableSubtitles: [BitmovinPlayer.SubtitleTrack] { return player.availableSubtitles }
+    public var availableSubtitles: [SubtitleTrack] { return player.availableSubtitles }
 
-    public var subtitle: BitmovinPlayer.SubtitleTrack { return player.subtitle }
+    public var subtitle: SubtitleTrack { return player.subtitle }
 
-    public var availableAudio: [BitmovinPlayer.AudioTrack] { return player.availableAudio }
+    public var availableAudio: [AudioTrack] { return player.availableAudio }
 
-    public var audio: BitmovinPlayer.AudioTrack? { return player.audio }
+    public var audio: AudioTrack? { return player.audio }
 
     public var isAd: Bool {
         if sessionStatus != .notInitialised {
@@ -72,9 +72,9 @@ public class BitmovinYospacePlayer: NSObject, Player {
 
     public var isAirPlayAvailable: Bool { return player.isAirPlayAvailable }
 
-    public var availableVideoQualities: [BitmovinPlayer.VideoQuality] { return player.availableVideoQualities }
+    public var availableVideoQualities: [VideoQuality] { return player.availableVideoQualities }
 
-    public var videoQuality: BitmovinPlayer.VideoQuality? { return player.videoQuality }
+    public var videoQuality: VideoQuality? { return player.videoQuality }
 
     public var playbackSpeed: Float {
         get { return player.playbackSpeed }
@@ -90,7 +90,7 @@ public class BitmovinYospacePlayer: NSObject, Player {
 
     public var buffer: BufferApi { return player.buffer }
 
-    public var playlist: BitmovinPlayer.PlaylistApi { return player.playlist }
+    public var playlist: PlaylistApi { return player.playlist }
 
     public var isCasting: Bool { return player.isCasting }
 
@@ -101,7 +101,20 @@ public class BitmovinYospacePlayer: NSObject, Player {
     public var isOutputObscured: Bool { return player.isOutputObscured }
 
     @available(iOS 15.0, *)
-    public var sharePlay: BitmovinPlayer.SharePlayApi { return player.sharePlay }
+    public var sharePlay: SharePlayApi { return player.sharePlay }
+
+    public var _modules: _PlayerModulesApi { player._modules }
+
+    public var events: PlayerEventsApi {
+        BitLog.w(
+            """
+            Using `Player.events` is discouraged in combination with the Yospace Integration. \
+            Events will not contain Yospace related data. Use `Player.add(listener:)` instead.
+            """
+        )
+        return player.events
+    }
+
 
     // MARK: - Bitmovin Player methods
 
@@ -109,11 +122,11 @@ public class BitmovinYospacePlayer: NSObject, Player {
         player.load(sourceConfig: sourceConfig)
     }
 
-    public func load(source: BitmovinPlayer.Source) {
+    public func load(source: Source) {
         player.load(source: source)
     }
 
-    public func load(playlistConfig: BitmovinPlayer.PlaylistConfig) {
+    public func load(playlistConfig: PlaylistConfig) {
         player.load(playlistConfig: playlistConfig)
     }
 
@@ -130,7 +143,7 @@ public class BitmovinYospacePlayer: NSObject, Player {
     }
 
     @available(*, deprecated, message: "Use SourceConfig#add(subtitleTrack:) instead.")
-    public func addSubtitle(track subtitleTrack: BitmovinPlayer.SubtitleTrack) {
+    public func addSubtitle(track subtitleTrack: SubtitleTrack) {
         player.addSubtitle(track: subtitleTrack)
     }
 

--- a/BitmovinYoSpaceModule/Classes/DateRangeEmitter.swift
+++ b/BitmovinYoSpaceModule/Classes/DateRangeEmitter.swift
@@ -1,4 +1,4 @@
-import BitmovinPlayer
+import BitmovinPlayerCore
 import Foundation
 import YOAdManagement
 

--- a/BitmovinYoSpaceModule/Classes/PlayheadNormalizer.swift
+++ b/BitmovinYoSpaceModule/Classes/PlayheadNormalizer.swift
@@ -5,7 +5,7 @@
 //  Created by cdg on 2/4/21.
 //
 
-import BitmovinPlayer
+import BitmovinPlayerCore
 import Foundation
 
 enum Mode: String {

--- a/BitmovinYoSpaceModule/Classes/YospaceAd.swift
+++ b/BitmovinYoSpaceModule/Classes/YospaceAd.swift
@@ -5,7 +5,7 @@
 //  Created by aneurinc on 2/14/20.
 //
 
-import BitmovinPlayer
+import BitmovinPlayerCore
 import Foundation
 import YOAdManagement
 

--- a/BitmovinYoSpaceModule/Classes/YospaceAdBreak.swift
+++ b/BitmovinYoSpaceModule/Classes/YospaceAdBreak.swift
@@ -5,7 +5,7 @@
 //  Created by aneurinc on 2/14/20.
 //
 
-import BitmovinPlayer
+import BitmovinPlayerCore
 import Foundation
 
 public class YospaceAdBreak: NSObject, AdBreak {

--- a/BitmovinYoSpaceModule/Classes/YospaceAdStartedEvent.swift
+++ b/BitmovinYoSpaceModule/Classes/YospaceAdStartedEvent.swift
@@ -1,4 +1,4 @@
-import BitmovinPlayer
+import BitmovinPlayerCore
 import Foundation
 import YOAdManagement
 

--- a/BitmovinYoSpaceModule/Classes/YospaceEventCode.swift
+++ b/BitmovinYoSpaceModule/Classes/YospaceEventCode.swift
@@ -1,4 +1,4 @@
-import BitmovinPlayer
+import BitmovinPlayerCore
 import Foundation
 
 @frozen

--- a/BitmovinYoSpaceModule/Classes/YospaceEvents.swift
+++ b/BitmovinYoSpaceModule/Classes/YospaceEvents.swift
@@ -1,4 +1,4 @@
-import BitmovinPlayer
+import BitmovinPlayerCore
 import Foundation
 
 public class YospaceWarningEvent: NSObject, Event {

--- a/BitmovinYoSpaceModule/Classes/YospaceId3MetadataEntry.swift
+++ b/BitmovinYoSpaceModule/Classes/YospaceId3MetadataEntry.swift
@@ -5,7 +5,7 @@
 //  Created by aneurinc on 11/23/20.
 //
 
-import BitmovinPlayer
+import BitmovinPlayerCore
 
 public class YospaceId3MetadataEntry: NSObject, MetadataEntry {
     public var metadataType: MetadataType

--- a/BitmovinYoSpaceModule/Classes/YospaceListener.swift
+++ b/BitmovinYoSpaceModule/Classes/YospaceListener.swift
@@ -5,7 +5,7 @@
 //  Created by Bitmovin on 11/13/18.
 //
 
-import BitmovinPlayer
+import BitmovinPlayerCore
 import Foundation
 
 public protocol YospaceListener: AnyObject {

--- a/BitmovinYoSpaceModule/Classes/YospaceSourceConfig.swift
+++ b/BitmovinYoSpaceModule/Classes/YospaceSourceConfig.swift
@@ -1,4 +1,4 @@
-import BitmovinPlayer
+import BitmovinPlayerCore
 import UIKit
 
 public class YospaceSourceConfig {

--- a/BitmovinYoSpaceModule/Classes/YospaceUtil.swift
+++ b/BitmovinYoSpaceModule/Classes/YospaceUtil.swift
@@ -1,4 +1,4 @@
-import BitmovinPlayer
+import BitmovinPlayerCore
 import UIKit
 import YOAdManagement
 

--- a/BitmovinYospaceModule.podspec
+++ b/BitmovinYospaceModule.podspec
@@ -17,10 +17,9 @@ Pod::Spec.new do |s|
   s.tvos.source_files = 'BitmovinYospaceModule/Classes/**/*'
   s.tvos.exclude_files = 'BitmovinYospaceModule/Classes/BitmovinTruexRenderer.swift'
 
-  s.ios.dependency 'BitmovinPlayer', '~>3.37.0'
+  s.ios.dependency 'BitmovinPlayerCore', '~>3.40'
   s.ios.dependency 'YOAdManagement-Release', '~>3.5.2'
   s.ios.dependency 'TruexAdRenderer-iOS', '3.2.1'
-  s.tvos.dependency 'BitmovinPlayer', '~>3.37.0'
+  s.tvos.dependency 'BitmovinPlayerCore', '~>3.40'
   s.tvos.dependency 'YOAdManagement-Release', '~>3.5.2'
-
 end

--- a/Example/BitmovinYoSpaceModule/ViewController.swift
+++ b/Example/BitmovinYoSpaceModule/ViewController.swift
@@ -1,4 +1,4 @@
-import BitmovinPlayer
+import BitmovinPlayerCore
 import BitmovinYospaceModule
 import UIKit
 

--- a/Example/BitmovinYospaceModule.xcodeproj/project.pbxproj
+++ b/Example/BitmovinYospaceModule.xcodeproj/project.pbxproj
@@ -378,13 +378,13 @@
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-BitmovinYospaceModule_Example_tvOS/Pods-BitmovinYospaceModule_Example_tvOS-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/BitmovinYospaceModule-tvOS/BitmovinYospaceModule.framework",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/BitmovinPlayer/BitmovinPlayer.framework/BitmovinPlayer",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/BitmovinPlayerCore/BitmovinPlayerCore.framework/BitmovinPlayerCore",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/YOAdManagement-Release/YOAdManagement.framework/YOAdManagement",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/BitmovinYospaceModule.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/BitmovinPlayer.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/BitmovinPlayerCore.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/YOAdManagement.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -401,14 +401,14 @@
 				"${PODS_ROOT}/Target Support Files/Pods-BitmovinYospaceModule_Example/Pods-BitmovinYospaceModule_Example-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/BitmovinYospaceModule-iOS/BitmovinYospaceModule.framework",
 				"${PODS_ROOT}/TruexAdRenderer-iOS/TruexAdRenderer-iOS-v3.2.1/TruexAdRenderer.framework",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/BitmovinPlayer/BitmovinPlayer.framework/BitmovinPlayer",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/BitmovinPlayerCore/BitmovinPlayerCore.framework/BitmovinPlayerCore",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/YOAdManagement-Release/YOAdManagement.framework/YOAdManagement",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/BitmovinYospaceModule.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/TruexAdRenderer.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/BitmovinPlayer.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/BitmovinPlayerCore.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/YOAdManagement.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -479,7 +479,6 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"${PODS_CONFIGURATION_BUILD_DIR}/BitmovinYospaceModule-tvOS\"",
-					"\"${PODS_ROOT}/BitmovinPlayer/tvOS\"",
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = BitmovinYospaceModule_Example_tvOS/Info.plist;
@@ -671,8 +670,6 @@
 					"-framework",
 					"\"AVKit\"",
 					"-framework",
-					"\"BitmovinPlayer\"",
-					"-framework",
 					"\"Foundation\"",
 					"-framework",
 					"\"UIKit\"",
@@ -713,8 +710,6 @@
 					"\"AVFoundation\"",
 					"-framework",
 					"\"AVKit\"",
-					"-framework",
-					"\"BitmovinPlayer\"",
 					"-framework",
 					"\"Foundation\"",
 					"-framework",

--- a/Example/BitmovinYospaceModule_Example_tvOS/ViewController.swift
+++ b/Example/BitmovinYospaceModule_Example_tvOS/ViewController.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2018 CocoaPods. All rights reserved.
 //
 
-import BitmovinPlayer
+import BitmovinPlayerCore
 import BitmovinYospaceModule
 import UIKit
 

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,5 +1,6 @@
 source 'https://www.github.com/socialvibe/cocoapod-specs'
 source 'https://github.com/bitmovin/cocoapod-specs.git'
+source 'https://cdn.cocoapods.org/'
 
 plugin 'cocoapods-art', :sources => [
     'apple-sdk-release'
@@ -7,7 +8,7 @@ plugin 'cocoapods-art', :sources => [
 
 def shared_pods
     pod 'BitmovinYospaceModule', :path => '../'
-    pod 'BitmovinPlayer', '3.37.0'
+    pod 'BitmovinPlayerCore', '3.40.0'
     pod 'YOAdManagement-Release'
 end
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,21 +1,21 @@
 PODS:
-  - BitmovinPlayer (3.37.0)
-  - BitmovinYospaceModule (2.0.1):
-    - BitmovinPlayer (~> 3.37.0)
+  - BitmovinPlayerCore (3.40.0)
+  - BitmovinYospaceModule (2.1.0):
+    - BitmovinPlayerCore (~> 3.40)
     - TruexAdRenderer-iOS (= 3.2.1)
     - YOAdManagement-Release (~> 3.5.2)
   - TruexAdRenderer-iOS (3.2.1)
   - YOAdManagement-Release (3.5.2)
 
 DEPENDENCIES:
-  - BitmovinPlayer (= 3.37.0)
+  - BitmovinPlayerCore (= 3.40.0)
   - BitmovinYospaceModule (from `../`)
   - TruexAdRenderer-iOS (= 3.2.1)
   - YOAdManagement-Release
 
 SPEC REPOS:
   https://github.com/bitmovin/cocoapod-specs.git:
-    - BitmovinPlayer
+    - BitmovinPlayerCore
   https://www.github.com/socialvibe/cocoapod-specs:
     - TruexAdRenderer-iOS
   https://yospacerepo.jfrog.io/artifactory/api/pods/apple-sdk-release:
@@ -26,11 +26,11 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  BitmovinPlayer: c0211be8e974f67c7afa11e02964ee21e8ea8bea
-  BitmovinYospaceModule: 7dba91a25106783cef6ae0d4592c9d5fdfb386ec
+  BitmovinPlayerCore: f53717bbedf58ce9b34b0c257a93c5ddd2869e99
+  BitmovinYospaceModule: 8a0cae92a3fc5111d6d30441a42f436c895b5f24
   TruexAdRenderer-iOS: ae88dfba906c2ec8ad6f4a6ad150e42f2bbc3726
   YOAdManagement-Release: 4bcff4ff8e44b699d726936a4d17d73c2a00c6f6
 
-PODFILE CHECKSUM: ad86dd9c5d6a15d599634a61d0a1ac9d77ac8f15
+PODFILE CHECKSUM: d934a6b0f8086a25bb45a8b60378730fe030cea7
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2


### PR DESCRIPTION
## Description
Since quite some while already we distribute our Player with modules. The only dependency for the Yospace integration is the `BitmovinPlayerCore`. To not depend on more than needed this PR changes the dependency to the  `BitmovinPlayerCore` framework.