### PR TITLE
Fix build issues on tvOS

### DIFF
--- a/BitmovinYoSpaceModule/Classes/BitmovinYospacePlayer.swift
+++ b/BitmovinYoSpaceModule/Classes/BitmovinYospacePlayer.swift
@@ -100,7 +100,7 @@ public class BitmovinYospacePlayer: NSObject, Player {
 
     public var isOutputObscured: Bool { return player.isOutputObscured }
 
-    @available(iOS 15.0, *)
+    @available(iOS 15, tvOS 15, *)
     public var sharePlay: SharePlayApi { return player.sharePlay }
 
     public var _modules: _PlayerModulesApi { player._modules }


### PR DESCRIPTION
## Description
It's currently not possible to use the Yospace integration on tvOS. Building results in an error.

### Changs
Adding proper availability annotation to the `sharePlay` API namespace fixes this.