### PR TITLE
Minor Ad-event fixes

### DIFF
--- a/BitmovinYospacePlayer/Sources/BitmovinYospacePlayer/API/BitmovinYospacePlayer.swift
+++ b/BitmovinYospacePlayer/Sources/BitmovinYospacePlayer/API/BitmovinYospacePlayer.swift
@@ -27,7 +27,13 @@ public class BitmovinYospacePlayer: NSObject, Player {
 
     public var isLive: Bool { return player.isLive }
 
-    public var duration: TimeInterval { player.duration - adBreaks.reduce(0) { $0 + $1.duration } }
+    public var duration: TimeInterval {
+        guard isAd, let activeAd else {
+            return player.duration - adBreaks.reduce(0) { $0 + $1.duration }
+        }
+
+        return activeAd.duration
+    }
 
     public var currentTime: TimeInterval {
         if isAd {

--- a/BitmovinYospacePlayer/Sources/BitmovinYospacePlayer/API/BitmovinYospacePlayer.swift
+++ b/BitmovinYospacePlayer/Sources/BitmovinYospacePlayer/API/BitmovinYospacePlayer.swift
@@ -109,7 +109,7 @@ public class BitmovinYospacePlayer: NSObject, Player {
     public var playlist: PlaylistApi { return player.playlist }
 
     public lazy var ads: BitmovinPlayerCore.AdvertisingApi = {
-        return BitmovinAdsApiProxy(yospacePlayer: self)
+        return YospaceAdvertisingApi(yospacePlayer: self)
     }()
 
     public var isCasting: Bool { return player.isCasting }

--- a/BitmovinYospacePlayer/Sources/BitmovinYospacePlayer/API/BitmovinYospacePlayer.swift
+++ b/BitmovinYospacePlayer/Sources/BitmovinYospacePlayer/API/BitmovinYospacePlayer.swift
@@ -714,33 +714,26 @@ public extension BitmovinYospacePlayer {
     @objc func advertDidEnd(notification: NSNotification) {
         BitLog.d("YoSpace advertDidEnd")
 
-        if let dict = notification.userInfo as NSDictionary? {
-            if let YOAd = dict[YOAdvertKey] as? YOAdvert {
-                let ad = createActiveAd(advert: YOAd)
+        guard let activeAd else { return }
 
-                BitLog.d("Emitting AdFinishedEvent")
-                let adFinishedEvent = AdFinishedEvent(ad: ad)
-                eventBus.emit(event: adFinishedEvent)
-            }
-        }
+        BitLog.d("Emitting AdFinishedEvent")
+        let adFinishedEvent = AdFinishedEvent(ad: activeAd)
+        eventBus.emit(event: adFinishedEvent)
 
-        activeAd = nil
+        self.activeAd = nil
     }
 
     @objc func advertBreakDidEnd(notification: NSNotification) {
         BitLog.d("YoSpace advertBreakDidEnd")
 
-        if let dict = notification.userInfo as NSDictionary? {
-            if let YOAdBreak = dict[YOAdBreakKey] as? YOAdBreak, !isLive {
-                let adBreak = createActiveAdBreak(adBreak: YOAdBreak)
 
-                BitLog.d("Emitting AdBreakFinishedEvent")
-                let adBreakFinishedEvent = AdBreakFinishedEvent(adBreak: adBreak)
-                eventBus.emit(event: adBreakFinishedEvent)
-            }
-        }
+        guard let activeAdBreak else { return }
 
-        activeAdBreak = nil
+        BitLog.d("Emitting AdBreakFinishedEvent")
+        let adBreakFinishedEvent = AdBreakFinishedEvent(adBreak: activeAdBreak)
+        eventBus.emit(event: adBreakFinishedEvent)
+
+        self.activeAdBreak = nil
     }
 
     @objc func trackingEventDidOccur(notification: NSNotification) {

--- a/BitmovinYospacePlayer/Sources/BitmovinYospacePlayer/API/BitmovinYospacePlayer.swift
+++ b/BitmovinYospacePlayer/Sources/BitmovinYospacePlayer/API/BitmovinYospacePlayer.swift
@@ -1132,6 +1132,7 @@ extension YOAdvert {
             isLinear: interactiveCreative == nil,
             clickThroughUrl: URL(string: linearCreative.clickthroughUrl() ?? ""),
             mediaFileUrl: URL(string: interactiveCreative?.source ?? ""),
+            skippableAfter: skipOffset,
             clickThroughUrlOpened: { }
         )
     }

--- a/BitmovinYospacePlayer/Sources/BitmovinYospacePlayer/API/Model/YospaceAd.swift
+++ b/BitmovinYospacePlayer/Sources/BitmovinYospacePlayer/API/Model/YospaceAd.swift
@@ -97,7 +97,7 @@ public class YospaceAd: NSObject, LinearAd {
         var jsonData = [AnyHashable: Any]()
         jsonData["uiConfig"] = uiConfigJsonData
         jsonData["isLinear"] = isLinear
-//        jsonData["skippableAfter"] = skippableAfter
+        jsonData["skippableAfter"] = skippableAfter
         return jsonData
     }
 }

--- a/BitmovinYospacePlayer/Sources/BitmovinYospacePlayer/API/Model/YospaceAd.swift
+++ b/BitmovinYospacePlayer/Sources/BitmovinYospacePlayer/API/Model/YospaceAd.swift
@@ -9,13 +9,13 @@ import BitmovinPlayerCore
 import Foundation
 import YOAdManagement
 
-public class YospaceAd: NSObject, Ad {
+public class YospaceAd: NSObject, LinearAd {
     public var identifier: String?
     public let creativeId: String?
     public let sequence: String?
     public let absoluteStart: TimeInterval
     public let relativeStart: TimeInterval
-    public let duration: TimeInterval
+    public var duration: TimeInterval
     public let absoluteEnd: TimeInterval
     public let system: String?
     public let title: String?
@@ -30,6 +30,8 @@ public class YospaceAd: NSObject, Ad {
     public var width: Int = -1
     public var height: Int = -1
     public var mediaFileUrl: URL?
+    public var skippableAfter: TimeInterval
+    public var uiConfig: BitmovinPlayerCore.LinearAdUiConfig?
     public var clickThroughUrlOpened: (() -> Void)?
 
     required init(
@@ -50,6 +52,7 @@ public class YospaceAd: NSObject, Ad {
         isLinear: Bool,
         clickThroughUrl: URL?,
         mediaFileUrl: URL?,
+        skippableAfter: TimeInterval,
         clickThroughUrlOpened: (() -> Void)?
     ) {
         self.identifier = identifier
@@ -69,6 +72,7 @@ public class YospaceAd: NSObject, Ad {
         self.isLinear = isLinear
         self.clickThroughUrl = clickThroughUrl
         self.mediaFileUrl = mediaFileUrl
+        self.skippableAfter = skippableAfter
         self.clickThroughUrlOpened = clickThroughUrlOpened
     }
 

--- a/BitmovinYospacePlayer/Sources/BitmovinYospacePlayer/API/Model/YospaceAd.swift
+++ b/BitmovinYospacePlayer/Sources/BitmovinYospacePlayer/API/Model/YospaceAd.swift
@@ -91,6 +91,13 @@ public class YospaceAd: NSObject, LinearAd {
 
     // swiftlint:disable:next identifier_name
     public func _toJsonData() -> [AnyHashable: Any] {
-        return [:]
+        var uiConfigJsonData = [AnyHashable: Any]()
+        uiConfigJsonData["requestsUi"] = true
+
+        var jsonData = [AnyHashable: Any]()
+        jsonData["uiConfig"] = uiConfigJsonData
+        jsonData["isLinear"] = isLinear
+//        jsonData["skippableAfter"] = skippableAfter
+        return jsonData
     }
 }

--- a/BitmovinYospacePlayer/Sources/BitmovinYospacePlayer/Helper/Ads/BitmovinAdsApiProxy.swift
+++ b/BitmovinYospacePlayer/Sources/BitmovinYospacePlayer/Helper/Ads/BitmovinAdsApiProxy.swift
@@ -1,0 +1,29 @@
+import BitmovinPlayerCore
+
+class BitmovinAdsApiProxy: AdvertisingApi {
+    private weak var yospacePlayer: BitmovinYospacePlayer?
+
+    var schedule: [AdBreak] {
+        yospacePlayer?.timeline?.adBreaks ?? []
+    }
+
+    init(yospacePlayer: BitmovinYospacePlayer) {
+        self.yospacePlayer = yospacePlayer
+    }
+
+    func skip() {
+        guard let yospacePlayer, let activeAdBreak = yospacePlayer.activeAdBreak else {
+            return
+        }
+
+        yospacePlayer.player.seek(time: activeAdBreak.absoluteEnd)
+    }
+
+    func schedule(adItem: AdItem) {
+        BitLog.w("Scheduling client side Ads is not supported!")
+    }
+
+    func register(adContainer: UIView) {
+        BitLog.w("Registering a separate AdContainer is not supported!")
+    }
+}

--- a/BitmovinYospacePlayer/Sources/BitmovinYospacePlayer/Helper/Ads/BitmovinAdsApiProxy.swift
+++ b/BitmovinYospacePlayer/Sources/BitmovinYospacePlayer/Helper/Ads/BitmovinAdsApiProxy.swift
@@ -1,6 +1,6 @@
 import BitmovinPlayerCore
 
-class BitmovinAdsApiProxy: AdvertisingApi {
+class YospaceAdvertisingApi: AdvertisingApi {
     private weak var yospacePlayer: BitmovinYospacePlayer?
 
     var schedule: [AdBreak] {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   - `Player.events` will now properly include all Ad events
 - `Player.yospaceEvents` to listen to events from the Yospace integration (See `YospaceListener` for available events)
 - `BitmovinYospaceEvent` as parent type for all events from the Yospace integration
+- Support for skipping Ads
 
 ### Changed
 - **Migrated from CocoaPods to Swift Package Manager**
@@ -38,6 +39,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `YOAdManagement-Release` dependency to `3.10.3`
 - `TruexAdRenderer-iOS` dependency to `3.5.1`
 - `TruexAdRenderer-tvOS` dependency to `3.15.2`
+
+### Fixed
+- Missing `AdBreakFinished` and `AdFinished` events
+- Missing Advertising UI during Ads
 
 ### Removed
 - CocoaPods support


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->

This PR fixes multiple issues regarding ad events:
- The AdStrated event was missing the `uiConfig` serialization to show our Advertising UI
- The `player.duration` during an ad did not return the Ads duration
- Missing `AdFinsihed` event
- Missing `AdBreakFinished` event
- Missing Ad-skip functionality

## Checklist (for PR submitter and reviewers)
- [x] `CHANGELOG` entry
