### PR TITLE
Support TrueX on tvOS

### DIFF
--- a/BitmovinYospacePlayer/Sources/BitmovinYospacePlayer/Truex/TruexConfiguration.swift
+++ b/BitmovinYospacePlayer/Sources/BitmovinYospacePlayer/Truex/TruexConfiguration.swift
@@ -2,7 +2,11 @@ import Foundation
 import UIKit
 
 public class TruexConfiguration {
+#if os(iOS)
     public private(set) var view: UIView
+#else
+    public private(set) var view: UIViewController
+#endif
     public private(set) var userId: String
     public private(set) var vastConfigUrl: String
 
@@ -16,9 +20,17 @@ public class TruexConfiguration {
      - userId:
      - vastConfigUrl:
      */
+#if os(iOS)
     public init(view: UIView, userId: String = "", vastConfigUrl: String = "") {
         self.view = view
         self.userId = userId
         self.vastConfigUrl = vastConfigUrl
     }
+#else
+    public init(view: UIViewController, userId: String = "", vastConfigUrl: String = "") {
+        self.view = view
+        self.userId = userId
+        self.vastConfigUrl = vastConfigUrl
+    }
+#endif
 }


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->
The `TruexAdRenderer` has a different API requirement for iOS and tvOS. The `.start` method requires an `UIView` on iOS and a `UIViewController` on tvOS. This PR properly respsects that in our `TruexConfiguration`.

## Checklist (for PR submitter and reviewers)
- [x] `CHANGELOG` entry **Already present**
